### PR TITLE
refactor: Renamed InstanceBuilder to ObjectBuilder

### DIFF
--- a/src/PerformantReflection/ObjectBuilder.cs
+++ b/src/PerformantReflection/ObjectBuilder.cs
@@ -4,19 +4,19 @@ using PerformantReflection.Reflection;
 
 namespace PerformantReflection
 {
-	public class InstanceBuilder<T>
+	public class ObjectBuilder<T>
 	where T : notnull, new()
 	{
 		private readonly ObjectAccessor _accessor;
 		private readonly T _result;
 
-		public InstanceBuilder()
+		public ObjectBuilder()
 		{
 			_result = TypeInstantiator.CreateInstance<T>();
 			_accessor = new ObjectAccessor(_result);
 		}
 
-		public InstanceBuilder<T> With<TValue>(Expression<Func<T, TValue?>> expression, TValue value)
+		public ObjectBuilder<T> With<TValue>(Expression<Func<T, TValue?>> expression, TValue value)
 		{
 			var propertyName = ExpressionParser<T>.GetPropertyNameFromExpression(expression);
 			_accessor.Properties[propertyName].SetValue(value);

--- a/src/PerformantReflection/PerformantReflection.csproj
+++ b/src/PerformantReflection/PerformantReflection.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <Authors>Steffen Skov</Authors>
     <Company>Steffen Skov</Company>
     <Description>A super small library for making Reflection FAST.</Description>

--- a/tests/PerformantReflection.UnitTests/ObjectBuilderTests.cs
+++ b/tests/PerformantReflection.UnitTests/ObjectBuilderTests.cs
@@ -1,6 +1,6 @@
 namespace PerformantReflection.UnitTests;
 
-public class InstanceBuilderTests
+public class ObjectBuilderTests
 {
 	private class Fake
 	{
@@ -12,7 +12,7 @@ public class InstanceBuilderTests
 	public void With_PropertyName_Valid()
 	{
 		// Arrange
-		var builder = new InstanceBuilder<Fake>();
+		var builder = new ObjectBuilder<Fake>();
 		var id = Guid.NewGuid();
 		
 		// Act
@@ -27,7 +27,7 @@ public class InstanceBuilderTests
 	public void With_AnonymousType_Throws()
 	{
 		// Arrange
-		var builder = new InstanceBuilder<Fake>();
+		var builder = new ObjectBuilder<Fake>();
 
 		// Act && Assert
 		var ex = Assert.Throws<NotSupportedException>(() =>  builder.With(instance => new { instance.Name }, null));


### PR DESCRIPTION
Renamed InstanceBuilder to ObjectBuilder, to better follow the same naming convention otherwise used within the library