### PR TITLE
fix: Retain interface default implemented methods

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <!-- Directory.Build.props -->
 <Project>
     <PropertyGroup>
-        <Version>1.9.0</Version>
+        <Version>1.9.1</Version>
     </PropertyGroup>
 </Project>
 

--- a/src/PerformantReflection/InterfaceImplementationGenerator.cs
+++ b/src/PerformantReflection/InterfaceImplementationGenerator.cs
@@ -188,7 +188,7 @@ public static class InterfaceImplementationGenerator
 		}
 
 		var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-			.Where(method => !method.IsSpecialName); // IsSpecialName == implementation of properties etc. so skip those
+			.Where(method => method is { IsSpecialName: false, IsAbstract: true }); // IsSpecialName == implementation of properties etc. so skip those
 		foreach (var method in methods)
 		{
 			CreateMethod(typeBuilder, method);

--- a/src/PerformantReflection/InterfaceImplementationGenerator.cs
+++ b/src/PerformantReflection/InterfaceImplementationGenerator.cs
@@ -221,9 +221,10 @@ public static class InterfaceImplementationGenerator
 	private static string FormatMethodDescription(MethodInfo method)
 	{
 		var actualMethodName = method.Name.Split('.').Last();
+		var genArity = method.IsGenericMethodDefinition ? $"`{method.GetGenericArguments().Length}" : string.Empty;
 		var ret = FormatType(method.ReturnType);
 		var parms = string.Join(",", method.GetParameters().Select(p => FormatType(p.ParameterType)));
-		return $"{actualMethodName}|{ret}|({parms})";
+		return $"{actualMethodName}{genArity}|{ret}|({parms})";
 	}
 
 	private static string FormatType(Type t)

--- a/src/PerformantReflection/InterfaceImplementationGenerator.cs
+++ b/src/PerformantReflection/InterfaceImplementationGenerator.cs
@@ -203,7 +203,7 @@ public static class InterfaceImplementationGenerator
 
 		var explicitMethods = type
 			.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-			.Where(m => m is { IsSpecialName: false, IsAbstract: false } && m.Name.Contains('.'));
+			.Where(m => m is { IsSpecialName: false, IsAbstract: false });
 		foreach (var method in explicitMethods)
 		{
 			var methodName = FormatMethodDescription(method);

--- a/tests/PerformantReflection.UnitTests/Builders/InterfaceObjectBuilderTests.cs
+++ b/tests/PerformantReflection.UnitTests/Builders/InterfaceObjectBuilderTests.cs
@@ -23,7 +23,7 @@ public class InterfaceObjectBuilderTests
 	}
 
 	[Fact]
-	public void CreateInstance_TypeImplementsNestedInterface_Works()
+	public void Build_TypeImplementsNestedInterface_Works()
 	{
 		// Arrange
 		var builder = new InterfaceObjectBuilder<ICustomerAggregate>();
@@ -37,6 +37,21 @@ public class InterfaceObjectBuilderTests
 		// Assert
 		Assert.Equal(id, result.Id);
 		Assert.True(result.Deleted);
+	}
+
+	[Fact]
+	public void Build_InterfaceWithDefaultMethodImplementation_RetainsDefaultImplementation()
+	{
+		// Arrange
+		var builder = new InterfaceObjectBuilder<IWithDefaultMethodImplementation>()
+			.With(e => e.GivenName, "Given")
+			.With(e => e.SurName, "Sur");
+
+		// Act
+		var instance = builder.Build();
+
+		// Assert
+		Assert.Equal("Given Sur", instance.GetDisplayName());
 	}
 
 	public interface IFake : IBaseFake
@@ -61,5 +76,18 @@ public class InterfaceObjectBuilderTests
 
 	public interface ICustomerAggregate : IAggregate<Guid>
 	{
+	}
+
+	public interface IWithDefaultMethodImplementation
+	{
+		string GivenName { get; }
+		string SurName { get; }
+
+		string GetDisplayName()
+		{
+			return $"{GivenName} {SurName}";
+		}
+
+		string EmptyMethod();
 	}
 }

--- a/tests/PerformantReflection.UnitTests/Builders/InterfaceObjectBuilderTests.cs
+++ b/tests/PerformantReflection.UnitTests/Builders/InterfaceObjectBuilderTests.cs
@@ -51,7 +51,9 @@ public class InterfaceObjectBuilderTests
 		var instance = builder.Build();
 
 		// Assert
+		Assert.Equal("Given Sur", instance.BaseMethod());
 		Assert.Equal("Given Sur", instance.GetDisplayName());
+		Assert.Null(instance.EmptyMethod()); // auto-generated empty implementation
 	}
 
 	public interface IFake : IBaseFake
@@ -78,10 +80,15 @@ public class InterfaceObjectBuilderTests
 	{
 	}
 
-	public interface IWithDefaultMethodImplementation
+	public interface IWithDefaultMethodImplementation : IBase
 	{
 		string GivenName { get; }
 		string SurName { get; }
+
+		string IBase.BaseMethod()
+		{
+			return GetDisplayName();
+		}
 
 		string GetDisplayName()
 		{
@@ -89,5 +96,10 @@ public class InterfaceObjectBuilderTests
 		}
 
 		string EmptyMethod();
+	}
+
+	public interface IBase
+	{
+		string BaseMethod();
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves default interface method implementations when generating implementations.
  * Improves handling of abstract, default, explicit and inherited interface members for more accurate behavior.
  * Adds deduplication to prevent duplicate method implementations across interface hierarchies.

* **Tests**
  * Added coverage to verify retention of default interface method implementations.
  * Renamed a test for consistency with builder terminology.

* **Chores**
  * Bumped version to 1.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->